### PR TITLE
typo fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Example for encoding and decoding:
   sms = smsutil.split('[the quick brown fox]')
   len(sms.parts)  # 1
   sms.encoding  # 'gsm0338'
-  sms.parts[0].content  # 'the quick brown fox.'
+  sms.parts[0].content  # '[the quick brown fox]'
   sms.parts[0].length  # 21
   sms.parts[0].bytes  # 23
 


### PR DESCRIPTION
Line 49 and 52 didn't correspond. Fixed. Verified in the REPL.

```
>>> sms = smsutil.split('[the quick brown fox]')
>>> sms
<SplitResult [<Part "[the quick brown fox]">]>
>>> sms.parts
[<Part "[the quick brown fox]">]
>>> sms.parts[0]
<Part "[the quick brown fox]">
>>> sms.parts[0].content
'[the quick brown fox]'
>>> sms.parts[0].length
21
>>> sms.parts[0].bytes
23
>>> sms.parts[0].encoding
```