### PR TITLE
Setup: Fix encoding issue while installing package (#5)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ from setuptools import setup
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-with open('README.rst') as readme_file:
+with open('README.rst', 'r', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 about = {}
-with open(os.path.join(BASE_DIR, 'smsutil', '__version__.py')) as f:
+with open(os.path.join(BASE_DIR, 'smsutil', '__version__.py'), 'r', encoding='utf-8') as f:
     exec(f.read(), about)
 
 


### PR DESCRIPTION
Python opens files using the encoding returned by
locale.getpreferredencoding(), which is 'cp1252' in Windows.
For cross-platform compatibility, it is needed to explicitly
specify 'utf-8' when reading files.

File is also opened in read-only since it is not necessary
to have write access to README and LICENCE files during install.