### PR TITLE
Less strict version of future package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with io.open(os.path.join(BASE_DIR, 'smsutil', '__version__.py'), 'r', encoding=
 
 
 requirements = [
-    'future==0.16.0'
+    'future>=0.16.0'
 ]
 
 test_requirements = [


### PR DESCRIPTION
I ran into some installation problems when installing together with other packages that depend on `future>=0.18.0`.